### PR TITLE
feat: add clear dagrun endpoint

### DIFF
--- a/derived_dag_api/utils.py
+++ b/derived_dag_api/utils.py
@@ -5,6 +5,8 @@ from urllib.parse import urlparse
 from airflow.models import DagBag
 from flask import jsonify, make_response
 
+from .models import DerivedPipelines
+
 
 def get_database_uri():
     parsed_uri = urlparse(os.environ['AIRFLOW__CORE__SQL_ALCHEMY_CONN'])
@@ -27,3 +29,7 @@ def collect_dags():
     dag_bag = DagBag()
     dag_bag.sync_to_db()
     print("Finished collecting and syncing dags")
+
+
+def derived_dag_exists(session, dag_id):
+    return session.query(DerivedPipelines).filter(DerivedPipelines.dag_id == dag_id).first() is not None


### PR DESCRIPTION
Adds a new endpoint to the API that clears the last run of a derived pipeline. This is necessary because when users manually run a pipeline it affects the next scheduled run. Clearing the last run has no effect on the schedule.